### PR TITLE
Remove decorators, improve error handling and timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # What is this?
 
 This is a really simple bot that is meant to help people in the Speedrun.com
-[Discord server](https://discord.gg/0h6sul1ZwHVpXJmK) to assist new members.
-So they can ask questions in the relevant place.
+[Discord server](https://discord.gg/0h6sul1ZwHVpXJmK) to assist new members. So
+they can ask questions in the relevant place.
 
 # Features
 
-- It looks up a game or series and sends the Discord invite. If there isn't one, it
-  sends a link to their forums
+- It looks up a game or series and sends the Discord invite. If there isn't one,
+  it sends a link to their forums
 - Optionally, it's able to ping a user, to notify them as to where to ask
 - Can send a link this source code on GitHub
 

--- a/deno.json
+++ b/deno.json
@@ -1,0 +1,5 @@
+{
+	"fmt": {
+		"useTabs": true
+	}
+}

--- a/deno.lock
+++ b/deno.lock
@@ -1,0 +1,308 @@
+{
+  "version": "3",
+  "packages": {
+    "specifiers": {
+      "jsr:@denosaurs/event@2.0.2": "jsr:@denosaurs/event@2.0.2",
+      "jsr:@std/assert@^0.217.0": "jsr:@std/assert@0.217.0",
+      "jsr:@std/bytes@^0.217.0": "jsr:@std/bytes@0.217.0",
+      "jsr:@std/encoding@0.217": "jsr:@std/encoding@0.217.0",
+      "jsr:@std/fs@0.217": "jsr:@std/fs@0.217.0",
+      "jsr:@std/io@0.217": "jsr:@std/io@0.217.0",
+      "jsr:@std/path@^0.217.0": "jsr:@std/path@0.217.0",
+      "npm:@evan/wasm@0.0.95": "npm:@evan/wasm@0.0.95",
+      "npm:redis@4.6.13": "npm:redis@4.6.13_@redis+client@1.5.14",
+      "npm:ts-mixer@6.0.0": "npm:ts-mixer@6.0.0"
+    },
+    "jsr": {
+      "@denosaurs/event@2.0.2": {
+        "integrity": "3310ba1a9e94dd60ccb09c6084fc818cc1cd50e543c56ef0c6199f1b89073392"
+      },
+      "@std/assert@0.217.0": {
+        "integrity": "c98e279362ca6982d5285c3b89517b757c1e3477ee9f14eb2fdf80a45aaa9642"
+      },
+      "@std/bytes@0.217.0": {
+        "integrity": "58209975707478fe12423d0b3270f4d400fd135a4edb1f50eeca8f92e34e6580"
+      },
+      "@std/encoding@0.217.0": {
+        "integrity": "b03e8ff94c98d6b6a02c02c5cf8e5d203400155516248964fc4559abc04669dc"
+      },
+      "@std/fs@0.217.0": {
+        "integrity": "0bfff5f3618d68c385b28b4ffbf3a15c98293a0f1186444458b62e0111ce77b2",
+        "dependencies": [
+          "jsr:@std/path@^0.217.0"
+        ]
+      },
+      "@std/io@0.217.0": {
+        "integrity": "08d3dd7c10956d1433be95306ec15179cdebe49a0ce5a74238fabf140bb74382",
+        "dependencies": [
+          "jsr:@std/bytes@^0.217.0"
+        ]
+      },
+      "@std/path@0.217.0": {
+        "integrity": "1217cc25534bca9a2f672d7fe7c6f356e4027df400c0e85c0ef3e4343bc67d11",
+        "dependencies": [
+          "jsr:@std/assert@^0.217.0"
+        ]
+      }
+    },
+    "npm": {
+      "@evan/wasm@0.0.95": {
+        "integrity": "sha512-fWW2p6iNhEVhsMStf3gj4UD+IQz2TZFunqRPjSeKYlVUHyoLoStNrW3XaiiEj4b7u/0mUPcvT4oYAauerDWF/Q==",
+        "dependencies": {}
+      },
+      "@redis/bloom@1.2.0_@redis+client@1.5.14": {
+        "integrity": "sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==",
+        "dependencies": {
+          "@redis/client": "@redis/client@1.5.14"
+        }
+      },
+      "@redis/client@1.5.14": {
+        "integrity": "sha512-YGn0GqsRBFUQxklhY7v562VMOP0DcmlrHHs3IV1mFE3cbxe31IITUkqhBcIhVSI/2JqtWAJXg5mjV4aU+zD0HA==",
+        "dependencies": {
+          "cluster-key-slot": "cluster-key-slot@1.1.2",
+          "generic-pool": "generic-pool@3.9.0",
+          "yallist": "yallist@4.0.0"
+        }
+      },
+      "@redis/graph@1.1.1_@redis+client@1.5.14": {
+        "integrity": "sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==",
+        "dependencies": {
+          "@redis/client": "@redis/client@1.5.14"
+        }
+      },
+      "@redis/json@1.0.6_@redis+client@1.5.14": {
+        "integrity": "sha512-rcZO3bfQbm2zPRpqo82XbW8zg4G/w4W3tI7X8Mqleq9goQjAGLL7q/1n1ZX4dXEAmORVZ4s1+uKLaUOg7LrUhw==",
+        "dependencies": {
+          "@redis/client": "@redis/client@1.5.14"
+        }
+      },
+      "@redis/search@1.1.6_@redis+client@1.5.14": {
+        "integrity": "sha512-mZXCxbTYKBQ3M2lZnEddwEAks0Kc7nauire8q20oA0oA/LoA+E/b5Y5KZn232ztPb1FkIGqo12vh3Lf+Vw5iTw==",
+        "dependencies": {
+          "@redis/client": "@redis/client@1.5.14"
+        }
+      },
+      "@redis/time-series@1.0.5_@redis+client@1.5.14": {
+        "integrity": "sha512-IFjIgTusQym2B5IZJG3XKr5llka7ey84fw/NOYqESP5WUfQs9zz1ww/9+qoz4ka/S6KcGBodzlCeZ5UImKbscg==",
+        "dependencies": {
+          "@redis/client": "@redis/client@1.5.14"
+        }
+      },
+      "cluster-key-slot@1.1.2": {
+        "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+        "dependencies": {}
+      },
+      "generic-pool@3.9.0": {
+        "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+        "dependencies": {}
+      },
+      "redis@4.6.13_@redis+client@1.5.14": {
+        "integrity": "sha512-MHgkS4B+sPjCXpf+HfdetBwbRz6vCtsceTmw1pHNYJAsYxrfpOP6dz+piJWGos8wqG7qb3vj/Rrc5qOlmInUuA==",
+        "dependencies": {
+          "@redis/bloom": "@redis/bloom@1.2.0_@redis+client@1.5.14",
+          "@redis/client": "@redis/client@1.5.14",
+          "@redis/graph": "@redis/graph@1.1.1_@redis+client@1.5.14",
+          "@redis/json": "@redis/json@1.0.6_@redis+client@1.5.14",
+          "@redis/search": "@redis/search@1.1.6_@redis+client@1.5.14",
+          "@redis/time-series": "@redis/time-series@1.0.5_@redis+client@1.5.14"
+        }
+      },
+      "ts-mixer@6.0.0": {
+        "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ==",
+        "dependencies": {}
+      },
+      "yallist@4.0.0": {
+        "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+        "dependencies": {}
+      }
+    }
+  },
+  "remote": {
+    "https://deno.land/std@0.224.0/dotenv/mod.ts": "0180eaeedaaf88647318811cdaa418cc64dc51fb08354f91f5f480d0a1309f7d",
+    "https://deno.land/std@0.224.0/dotenv/parse.ts": "09977ff88dfd1f24f9973a338f0f91bbdb9307eb5ff6085446e7c423e4c7ba0c",
+    "https://deno.land/std@0.224.0/dotenv/stringify.ts": "275da322c409170160440836342eaa7cf012a1d11a7e700d8ca4e7f2f8aa4615",
+    "https://deno.land/x/harmony@v2.9.1/deps.ts": "066ff5a909e6f9b04abdc6b7d71f22b5d8d72af463e07b8ed7a2e9fcfa8d6192",
+    "https://deno.land/x/harmony@v2.9.1/mod.ts": "104a4ae8d4a29c99f13c14b9fb7487b9dc8dbe1bb649060f16d4e59feafba1cf",
+    "https://deno.land/x/harmony@v2.9.1/src/cache/adapter.ts": "227cfd1fca519f8c0c37621c3706fdc249ec9df1043aaaad96894341ffeceb43",
+    "https://deno.land/x/harmony@v2.9.1/src/cache/default.ts": "c728244b49405c08e0390a73d3712a19f110cd8d1f5473d2849311ac513d5a85",
+    "https://deno.land/x/harmony@v2.9.1/src/cache/mod.ts": "e8cc80c705c86954a8544ec311f07a65600af38890a3c7124410c45a91968d0a",
+    "https://deno.land/x/harmony@v2.9.1/src/cache/redis.ts": "7edbba4fd442ee993e8ed5e761de44ac246ce8b7de99def0ea2f582c00c10e58",
+    "https://deno.land/x/harmony@v2.9.1/src/client/client.ts": "4c794040b0bb2ca3691ba095fd6383c680131308215dda81b0c267396013c83d",
+    "https://deno.land/x/harmony@v2.9.1/src/client/collectors.ts": "f8f4d80b5bdac255ffcf725a702f7180cf92678288137fa2d96399a102197553",
+    "https://deno.land/x/harmony@v2.9.1/src/client/mod.ts": "705b82fd8b2b5c32df18f356de57a4d9e4377a0cd2a0ca17cfb00e4b042be3ac",
+    "https://deno.land/x/harmony@v2.9.1/src/client/shard.ts": "f4d0017f613ec1e2b34fe52e69633ab0d2659167b1110893df65f8a2359acfdd",
+    "https://deno.land/x/harmony@v2.9.1/src/client/voice.ts": "dd403cec0ea8db33b41194df3f3264e0a4907190054bf2dbfe1b56dce51f31b3",
+    "https://deno.land/x/harmony@v2.9.1/src/commands/client.ts": "ae607c3f25140e5f19e5acae2f507388b590098df8f2d40b05a895084512b3ac",
+    "https://deno.land/x/harmony@v2.9.1/src/commands/command.ts": "d069c086168c873bd0a9d74f875dcee765532357853c3ec4891bcf1180a022d6",
+    "https://deno.land/x/harmony@v2.9.1/src/commands/extension.ts": "1e8e6902ee771614bfe13ebe1539b0374386f684bc362ac2f24a434571ef35e1",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/channelCreate.ts": "b95620f1b8f6d1291499860f1a93109b59c1d43f364fa2ea345fab94475b242f",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/channelDelete.ts": "471fc308d6a34de0d88cb602964a064d8065e622c2b7bfc0e9b14285560cb19b",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/channelPinsUpdate.ts": "f2e400aeb9a83509fbf338a3f445aabaa9f2513e6e12b344c993ddaddd8e00cb",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/channelUpdate.ts": "c335b9e98a72a8b6772122a2649424f22b42ad2706a451eb934063eb327d06cc",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildAuditLogEntryCreate.ts": "5e5d492e013fd61dcddaa1238de44ed5dfcd17615ec017e8f283498ddef47af1",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildBanAdd.ts": "4aea7c19fde3d19be593c219a1325d75e5a1fa27aa5a1e6e52e59cc3fccdb270",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildBanRemove.ts": "7416b0fd4c0953a35c5d2027154505010ae08ca219839233cc6f9cad00d4bf7d",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildCreate.ts": "30e9044e7a179d71089d4215ee6902a5ef320200a9b43c0d51180ac99bffbb85",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildDelete.ts": "3af16441faad0f125a970809409b5513a767e0ac2ba53d79ae0363ea7de3fdd4",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildEmojiUpdate.ts": "0e3b853317755e0b4221a8a259a6635b330e93c05cc347b847a2fc199135128e",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildIntegrationsUpdate.ts": "8a29116d28cf14464ede93abd2475e806a88685ebb6877cce8967d5dbfd8c0e7",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildMemberAdd.ts": "de2551f1ebed02f37d8cf828691f4e753677fcc586e8d3a73165e4416513b3e3",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildMemberRemove.ts": "27c57911d5a68b5b7a2487c796b1289fa23e1d0e17536b22abaeb56dd8004a2e",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildMemberUpdate.ts": "275946ff6af9369f4a4540eb776585d87e48e4ba950d1d6dd4941d7f399b2de3",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildMembersChunk.ts": "a4fbc4b8c01b65dd77e1454e49d770a63a1240c06e8fb8c052bd3682c97134f7",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildRoleCreate.ts": "10e17b837fd66a258136f9d96471d1c3cc1a9c058fddb59ec55521f79768f264",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildRoleDelete.ts": "5ae8e25d20aab648ad30bc143f03347d062459b08470e27b8c9873477126de8f",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildRoleUpdate.ts": "94a23201e8c21bb763b3d8845cf3991c2b618433a089e849c2c399eb71183ceb",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildStickersUpdate.ts": "5bd32d928ab2af388e2f876720f4c89c478209617af80f00655ab227cdd76b2a",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/guildUpdate.ts": "ced94b0bea8e494cbef8e61a8576f71416eaee79718a64dc59d43883abe7f075",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/interactionCreate.ts": "403ee91ea497fd5585c6b95bf9a54c66b0de90698e709819f27ad6caad042237",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/inviteCreate.ts": "c6a219ee104d965f6b5eabd7069d0e6f2e02f19a723b3681ecd2a28d8cddca95",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/inviteDelete.ts": "a0bf84cd89c6cb4ceb8e9b0bc88eacadf130ea52fc1f133ab386eada5194257c",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/messageCreate.ts": "12bf161677fec90d7b95da69ac20233f41aab9301a9e1144d6301a95c52cd6a7",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/messageDelete.ts": "2536d7466a16950bd4d5f1b7e4139f707e6b99cc57141d2f9727033664ffd45c",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/messageDeleteBulk.ts": "5ef5a39281ca4dd2826156480a288d2c3a4247291d2035768448cfc95bd14aa4",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/messageReactionAdd.ts": "e799f656096d9225e053bd9666294c5bb4f31896fd1a8c7682fcf0469bd3f482",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/messageReactionRemove.ts": "988481427bf99db045ee830d5145317a0c0b6500a39b242e99cb53454993cc3b",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/messageReactionRemoveAll.ts": "809b99d690ab54653485062fe2be72464bcf265ef4d0d329a0351b01cbe050f5",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/messageReactionRemoveEmoji.ts": "183955ca5be09a222aac21f4b765547eb081a7cd9c2b6ff6cfdf20e6c0a27905",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/messageUpdate.ts": "20b8ac5fa5a3cf4354e563a7ddc74c2e5b8c902e23091c5a9321b7bd89eb95b7",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/mod.ts": "66afcc515bbbecec47544cfc0980d2517678b1524da6717b66f22565411c26b8",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/presenceUpdate.ts": "bedd2c3f371b9a8b6238f7b7e15c683d1f26618faa6137270401dde3a12520cf",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/ready.ts": "fb5e5c898b2228d0efb411d497ed4b5cb5623768487f7e36a4b855968f91ef00",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/reconnect.ts": "b0b4fff4f47de44f0637ad7aea0920b775731dee15ea07c355741374e0676f04",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/resume.ts": "0b710b10459c523015541ab9a2150a4ded333d769d8f1d7c644b64b065639fcc",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/threadCreate.ts": "591982967e164354d42050a0f7fcc62a772d4e464c66462928c5cf8ee6b0753f",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/threadDelete.ts": "29ee5a3dd5e10fdbbc6974025d8746baaeb03362e0f8aeef07cdaae625958b28",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/threadListSync.ts": "0bc0f553f9776049289ebe79acde0a13e472da379ddfee59e8e25e5b02947d2b",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/threadMemberUpdate.ts": "ebd1bf33a5247f74c095d5f8b3df36f71f842a9b203be00be40579df11b7aea4",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/threadMembersUpdate.ts": "1757a014a012cc444ad42afe00c31194b00a33583853a5744484b6ada3e5d344",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/threadUpdate.ts": "4ada9ee46f8620d9b7f2e070c2d59b816643a27c556b246c4033173da71011c4",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/typingStart.ts": "4eda773351b78ecaddb3339f0a42a81a2c9227666515caf71c20e2b5301d2c7f",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/userUpdate.ts": "3ae2b0b590fcb09e36a45e07973e20703ae5b57a3ada2806dce99e25aed01126",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/voiceServerUpdate.ts": "67ebe6b1a99ec6589b6dc575cd2a088b4afd7dbf849e61355400bf3342393d7e",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/voiceStateUpdate.ts": "7dcbf587ff478563f6d404f3f5eed17ce9518316fda860af05cfde4697aef7e6",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/handlers/webhooksUpdate.ts": "04991c8e12ad97a32c502d2e55cf80d1ade2cc7e2bdd6ae00105a4a01b48c10b",
+    "https://deno.land/x/harmony@v2.9.1/src/gateway/mod.ts": "897f74b2b36b4589ffe42d111adacb80e04bff23b2a23696d65b2bfbb8d1103f",
+    "https://deno.land/x/harmony@v2.9.1/src/interactions/applicationCommand.ts": "04145a73c69690ca7522a1e2a9786a6d8817075c1531dec1f93f80632922ca16",
+    "https://deno.land/x/harmony@v2.9.1/src/interactions/client.ts": "7b480b30ca32d0bd3db916370d776ab1ba2c9c3017e29fa463a49dcb7559467b",
+    "https://deno.land/x/harmony@v2.9.1/src/interactions/commandModule.ts": "b2da3198b4c8464bcab97b43789beb223cbb121ad1f4a5bc452f773ecb72a597",
+    "https://deno.land/x/harmony@v2.9.1/src/interactions/decorators.ts": "c3c88bf23d9c69b82ea934bcf1d45ded47ce61928b706d57e9f51f24d08f2720",
+    "https://deno.land/x/harmony@v2.9.1/src/interactions/mod.ts": "561ab4a9737e2cec6d0c26bcfd7f4517b9373161ee7e213d1a4e46789ab5dda5",
+    "https://deno.land/x/harmony@v2.9.1/src/interactions/tsxComponents.ts": "567e15d74f7c63d0c9ffff8a092b3b2e86db53974e1084b88355d74e4287ba17",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/base.ts": "73e09354fac5ca7b0a0f74f0253ea7d5b0bdd16da7ede2531ab85876b652f6cf",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/baseChild.ts": "86045ed5559bb611f509952aa2988c1e3ec07b4bbce0ed3ea9c0c90b2c9e1bf3",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/channelThreads.ts": "e422ac6c31095fe27c1ed7b87ccb35a7dd5da51abeba60bcecceac37eb08254a",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/channels.ts": "5a5f9dd94fb41198294d6de9d2182a5b99ee2b3f1601c38bbbada936b33fa0da",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/emojis.ts": "e9a73ebc02a68a54037c793286b2cc094cb89b31e8f32da0b53d37dd90a64c3c",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/gatewayCache.ts": "8f673dde8a19e0339781f63268fa06b883645726a1e4d90b5dc3a6f891890613",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/guildChannelVoiceStates.ts": "2e3f0e5cc0ff722463d8ef5e65671f1081e82f668a3e4f49407aa45a7b7e1933",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/guildChannels.ts": "86a01d0354ae2976b46d07032863a06e21e80c3bcb8ba8c202bcad0cb6ed478a",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/guildEmojis.ts": "8b45b5c2ccebf3a49f01d66241f7ba45b8b76441dfd3badfd3c1d918cb790a0e",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/guildStickers.ts": "e08c0bb3ad60dcda71e6be59d2d8a73ab605cd0b1aed7e93d6c4927e33260695",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/guildVoiceStates.ts": "3dcc714aa2cd1848e684bb5ce8052550b4d970858d329ecb28acbc2f8656ca9b",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/guilds.ts": "f3aad565a6e40c6d2fcbef2f4a3925336a2112846fd7045951fc8f02822743b2",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/invites.ts": "863f8b6671df1a27ec9297a146c9df082cfe0589d047aaf010722d186fc24ea5",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/memberRoles.ts": "0e453d3c16e94c360c7877c1fc5e42a5a85b63dc595a7b61edfe1849ad8ef100",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/members.ts": "3fa5d9f6235b699ab9d85b698816f9e576d3c74c7ef865a331cf977ff545d162",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/messageReactions.ts": "5e370987071ed6b9d1b65bf00a8b90f04296b785ee3a94597998817fe77033ab",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/messages.ts": "eb044effe3d5b3993b82517562001de8c0597995be4e5a25c2fd0504483eb2dd",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/presences.ts": "3e417198f46cb4848fb75dd3b3cd0a705c5ee7158e982cb39e16df6e8a1e1174",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/reactionUsers.ts": "47e52f1f4282134f917373baae4fbc606da33ba3daf0a9149158c947f8bbe6c1",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/roles.ts": "d4c40edbb86ee16c40d0de9d8ee90079889dbb2f6b68449ad61e510bdc2d3d2a",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/stickers.ts": "4b93f511a2e67ea1ca5513075f85109da0f88feaa89aceb0efd1c007ec94fc67",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/threadMembers.ts": "2530754630d1e537e5849e5f552281fee65dde79eb7a727d481e0881135cce54",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/threads.ts": "c12bb7db6e1c66467e0061fa6917e1cd6f31c671a99e51d14371410eb7542453",
+    "https://deno.land/x/harmony@v2.9.1/src/managers/users.ts": "05c04b5712b69c183649d3b7366021093abe214c76da92d88b17a400cb93b873",
+    "https://deno.land/x/harmony@v2.9.1/src/rest/bucket.ts": "4e3bada0eefb8f6ca9c336be847ee1c121a8ef2d0ca1f3b7339a35744ea07386",
+    "https://deno.land/x/harmony@v2.9.1/src/rest/endpoints.ts": "a9c08d22a5375733c7804a5ae0f5578ea8593abddc15ab6a8def7acbf81b0cba",
+    "https://deno.land/x/harmony@v2.9.1/src/rest/error.ts": "bd8bb46443c3d0bb5e60f3ad87e080e11ac132c4a4dc58afa2c48d94c35e794e",
+    "https://deno.land/x/harmony@v2.9.1/src/rest/manager.ts": "4174496bef6626c91d9afbd06a1ca8992c8dc0046ecff2825ababea93ba31ec2",
+    "https://deno.land/x/harmony@v2.9.1/src/rest/mod.ts": "96b368e712eda4aceba394061c74f98a9ce157f924c9fc0b7fdde592d6162289",
+    "https://deno.land/x/harmony@v2.9.1/src/rest/queue.ts": "b4af52191b6315ab34652ef385d99866c062d2973c6d3599a184fb44bbc66fda",
+    "https://deno.land/x/harmony@v2.9.1/src/rest/request.ts": "2ce7c9d436984663b3325163b913520922db77f3c37bcd8facd945bf001d6131",
+    "https://deno.land/x/harmony@v2.9.1/src/rest/types.ts": "6c8abf8fe7302d6256c7424dbeee7f447b2521c54150f46e35b18eef1508b9eb",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/application.ts": "4f6113b54fa0c3028d98588c7579d80d13b78053e9210a453dfd297c374b6897",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/applicationCommand.ts": "e42a5dbbf23851d4fa34d7c96ae562d1d3c9015c7444dc752f0e414163dd3272",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/autocompleteInteraction.ts": "c4f046e49f18792b58fae66026e05e65ebd98ab361b1816771226fafc1f140a7",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/base.ts": "65c28b3a0711a78f0dd54b4230bd94497b74ea3cf267c78b7948849ea9e7707c",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/cdn.ts": "32bd607b16328cf2123eceb5d96d4e40285591b56b91d058ce160035d79c1cd2",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/channel.ts": "5c05bf9a3db901fc177db6f1d104b9d32728555a0faa9fb6b19e47bd36815167",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/dmChannel.ts": "bc142161003c0799187b5be92c0785e02e3ae63ad4ee98de5a0b3fc27b3fe019",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/embed.ts": "8429e9eb0e72185fb4980e02c8e70269f0811ff8a3207273ff10e4001e563338",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/emoji.ts": "6475074e49505ddfb58005f7fe4f5bf0780249f963fc8f0423e689de3b5f535d",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/groupChannel.ts": "df255e1926e44db28c9add22d09c3b57f58d8791cd98c935669903f1b02c10a6",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/guild.ts": "b7f6ed005353f15ff7f91e3164ea30eeb71602bcfdea78c8a52f196816617f5c",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/guildCategoryChannel.ts": "2558eb08fff2225d5355af086929b576d756eddb3d195bd47aacea25f9689761",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/guildForumChannel.ts": "2b7e4259417bd6fc49a08efe293e74fb697d8cc29510787d6667931ba9289d96",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/guildNewsChannel.ts": "10c5519849b562ef84c61f4642cb2e40eef61d001440e6c6cecf9485421cf95c",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/guildStageVoiceChannel.ts": "2ab0fe6eb1d56557853770b4264ed73c72ad2df3e6dea7841bf1bca3232791fc",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/guildStoreChannel.ts": "5945c5f648a2b4cbb2ea13aefb31d8d092596e83fbcf83a0eaa9258a107c7529",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/guildTextChannel.ts": "3547bda42c76197fc004445b8d792bb0e67512fbbc15d15a17148c0c13a7f01c",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/guildThreadAvailableChannel.ts": "aaff836c02854988ca526089545b136889b52f0a891a831af3d81c39cbf81e45",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/guildVoiceChannel.ts": "76a254326e8c9996c66843a0f97c80d1502039f144d5c7bdadf926b69c128918",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/guildVoiceStageChannel.ts": "2ab0fe6eb1d56557853770b4264ed73c72ad2df3e6dea7841bf1bca3232791fc",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/interactions.ts": "00c5e56cd193cd8d00dcb3248a8bb85ce082b73ad2cc73d56d0e2e5bedbb874f",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/invite.ts": "f4d5cbf29a11313265cd82b431db2b683d1186e935e9c7d121413c5e4939d221",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/member.ts": "6d20dcc3bcbb394fa34f60b0c3597d38518d994cfd48c642583e34d3b511616e",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/message.ts": "22ca219758280dca020d9cf89c19928a90aa229940181aa916756ae3e1d557aa",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/messageComponents.ts": "9694177a16fa091427eb094316f7c3b8779737dd0e13dae78bc98b63a8e571dc",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/messageMentions.ts": "5dd8d0c1eac656bcde2e2d5fb6e9d318a74f7428055d84c3b9fae70c05b78caf",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/messageReaction.ts": "52d7f0ba482b338fa5a7fb74964fa2ee7a2fe6f28257f5f17bd7240102afb6f8",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/messageSticker.ts": "2392ef407bbae90da120c6cf08b583d2153744cb79cb1d680e65e2fde5df024d",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/modalSubmitInteraction.ts": "b3b7c72ddff3f3de07200fc890af354a281ef7e185c5edc55a1640edc5d57cce",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/presence.ts": "4bf6e3c27a8e96d8fd05486363a197f5e36febae2f97809184c145d7b6c60755",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/resolvable.ts": "762c5954860ba2849dd1227fd9f76d8aee87a9f03741950e75db370f64328258",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/role.ts": "ea70392f0763c3c463fff5d60e522d987fc149a9d5c244926ca696d531e6941f",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/team.ts": "7f98de7356ba4925d42cc32107347d8e33a0fc3dcfab15bc070e3c698b47548d",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/template.ts": "68021bde76a50ea18f132cb8b6590a798962ba043fb7a2cb1b55ef2aaea5df4b",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/textChannel.ts": "f0febe7cae6d8f986a6fea829b05b07a95df2245d3e4d92826d1a16dd3ff23a8",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/threadChannel.ts": "46629b4480f4e8d0aabd1c24d98fd77de3461f55181114af3b8c70d61ba57fb0",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/user.ts": "1ab93b158586e05c987ca86bb1b1ce363ca8c9cc2e43ee04784219519be972dc",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/voiceState.ts": "b4e96b47e98310337ec6aa95db12d299e7d46ada98b68f89c305dd91682fef14",
+    "https://deno.land/x/harmony@v2.9.1/src/structures/webhook.ts": "954ce340212ba32d445b2d0c47656a5119fdb5a60361da656242461d2270c1e3",
+    "https://deno.land/x/harmony@v2.9.1/src/types/application.ts": "44b7a4c034178bd02b139b232167d5bca444fafa3272c0ee1472308ddb794012",
+    "https://deno.land/x/harmony@v2.9.1/src/types/applicationCommand.ts": "4b439fd358eaeec55b35f539169cdffe1385c0591217c76811dc617ead4e6f13",
+    "https://deno.land/x/harmony@v2.9.1/src/types/cdn.ts": "681ee16ca3424d4002341f90452d2aec618155e7bbfb81589236122a2bd4cc4c",
+    "https://deno.land/x/harmony@v2.9.1/src/types/channel.ts": "f19795f1aca0e6e2676645bc04dcf96648ce68a784c9fd57dbc0315bd7b37e4b",
+    "https://deno.land/x/harmony@v2.9.1/src/types/constants.ts": "5a56ec0c1145ca3025de92278145113390ebe2c56cecd13f3a3d02feafe7b7ba",
+    "https://deno.land/x/harmony@v2.9.1/src/types/emoji.ts": "96751c5e7a12f033f7bea536387e9a6a8e3afea6759970afc58ea80694419ec9",
+    "https://deno.land/x/harmony@v2.9.1/src/types/endpoint.ts": "84715f8bd5fe4d0905913530d0bb55f08230a17ee16cba3d1feb7b939c31ff9c",
+    "https://deno.land/x/harmony@v2.9.1/src/types/gateway.ts": "a6dde34a0e84f29afb39d9089529d99f490bcde29a71bf899ece8d5e524dbdca",
+    "https://deno.land/x/harmony@v2.9.1/src/types/gatewayBot.ts": "3c57f2b2df8060683220345b891b42ae0458d1b26461b51ffdfa1bd5ec48080b",
+    "https://deno.land/x/harmony@v2.9.1/src/types/gatewayResponse.ts": "111ee1bfbf341370345547a7e2f041cce47953679c9698df8c4c1e2fed1d0b21",
+    "https://deno.land/x/harmony@v2.9.1/src/types/guild.ts": "7d88bfd1b6954fd1dd67a8a3518565244736264a47b629feeb6256986883c3e2",
+    "https://deno.land/x/harmony@v2.9.1/src/types/interactions.ts": "fbffb40948c8344453b24eeb6fde137cc207830948e4d4907406aab5ab01b994",
+    "https://deno.land/x/harmony@v2.9.1/src/types/invite.ts": "90972a222decf5b0b5ecaab92b0fd0d817febc24a1cb7eaebebbbd19030a86b7",
+    "https://deno.land/x/harmony@v2.9.1/src/types/messageComponents.ts": "24ba27bb61e84ea115a7cb0b51a05898e47bf5d5076eca527b03dcc17fa9cec1",
+    "https://deno.land/x/harmony@v2.9.1/src/types/oauth.ts": "355b87753c56d89c63777f47d4ad884655bf9397da6e2ed986a0a7933eb9170f",
+    "https://deno.land/x/harmony@v2.9.1/src/types/permissionFlags.ts": "3c492485876091b3c513284bbde420c50ebe7f067634d3d55fb38338a179f1de",
+    "https://deno.land/x/harmony@v2.9.1/src/types/presence.ts": "9d572d8d78c50de3d14714b01a2b6ac398f5594149ff4252385cafff0efa5198",
+    "https://deno.land/x/harmony@v2.9.1/src/types/role.ts": "7fae955c86d93ee52f63104716c9bd0ee222c1fca1e8c5e4420e8b1bbe28c60d",
+    "https://deno.land/x/harmony@v2.9.1/src/types/team.ts": "c3b9b5ede67ffa781c52b064da458875d6a8d7b7ca4bf1cc81749230f0da45d8",
+    "https://deno.land/x/harmony@v2.9.1/src/types/template.ts": "8931a46027863777d536ef73f7b0101eb885eeb6c39c2c17db7d24d3096dda88",
+    "https://deno.land/x/harmony@v2.9.1/src/types/user.ts": "96022eea5c976b09933763ec7f1ad3f90a911c44f93ba9475397a6e2ca83b0ad",
+    "https://deno.land/x/harmony@v2.9.1/src/types/userFlags.ts": "fe49dbaba9b506a725316c7094c91c8c974d8f43bdae09071548e5a21ba83ecc",
+    "https://deno.land/x/harmony@v2.9.1/src/types/voice.ts": "05cba935fea8c7e0a06d757269ca5ecaccfb23806b3137e96553c4beba35a2ef",
+    "https://deno.land/x/harmony@v2.9.1/src/types/webhook.ts": "32af12c3deda11fbbe4f79e29d539f5b71426612c22902a870ade246b2888edd",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/bitfield.ts": "eb20ca0f5137b7d7449ef4005f75cc8224d42b415ffeffdab63650d110a385ab",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/channel.ts": "9eca98df912ddf471b54c9b57a03006f0f5790ded6160addfd496624bfa77f5d",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/channelTypes.ts": "7caa4b94df51f19be52f798f3ee878d80adf56c29c507cfb316575ec63301c77",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/collection.ts": "d99226afc4dbe0ef63c07b4a00a0e969d93daa87fcbdef6d6466a42409a45c0d",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/colorutil.ts": "79339f1fd42bbaf0c17b401911193f2a532d5aac7f82247e8483dfefdf8fa0b7",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/command.ts": "6ea7942006c9714c988b67886c0d487ae618e5b1501a49d1a16239815ad15f61",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/components.ts": "7a925c5d2f42e4989b7e3a5cbf36fcf7a82906afd76d71294b7d4185d60945a7",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/delay.ts": "501d3ff33a1018c962d13c4de1db9e99e41c936f70c1119bc428f3ee0145eb8f",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/dict.ts": "30c00e16f90b5a8162aede15966dae77527f71641ad36ad302e8efa056ce9cf3",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/encoding.ts": "0b4f03476c39a72d81492f9b39a71f3e73abfef9fd5bfeb7ac987eb991c663be",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/err_fmt.ts": "37baddade1b1707a96b38363754310ce9b9d1e41dc394e646e7af4026bbaa359",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/events.ts": "e48093fd1f9371e243e04a048ca9c313163e4b2bed4178f2b2ab26ad7e04fc45",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/fetchBase64.ts": "49169ccf927b7df5d28e4b556711456c9a6eef1ebefb4cae35871030b64e5196",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/intents.ts": "03e67cad9a4480a989919d168a222413fdf8d7d3a65d74986eb9ebd3753ac098",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/interactions.ts": "8b9809dddf5e237a9f0a694b05764d48a8e334607411c3c2b73611a49f981b7d",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/oauthURL.ts": "f8f95d95d0ed637af25cb060d7d351132cd4e456635c08b7042fd59e4539d263",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/permissions.ts": "d093e29839df3fed526e64a7fc4bc3c75cb62aec154d288a0f0cdf321c35fb4f",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/snakeCase.ts": "e634296601f4fe5b09e43ed3b491e3bac46dba5403622369cd47e4f79c0816d3",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/snowflake.ts": "a3715de195998b05fc9934a3db2017b6961ba57dd78b442c468763afd971fb2b",
+    "https://deno.land/x/harmony@v2.9.1/src/utils/userFlags.ts": "71ed6753d17aad3e36dee9ada7b48159b17b5151f7a2bdb75a27b352e3b01c4b"
+  }
+}


### PR DESCRIPTION
Decorators
----------
We have to remove decorators as they won't work in deno deploy's playground, as they require a deno.json file which is not available in single file setups

https://deno.com/deploy/changelog#es-decorators-are-enabled-on-deno-deploy-replacing-experimental-ts-decorators

Error handling
--------------
Add error logging on unexpected behaviour from speedrun.com or discord, as well as responding to the user in case something unexpected happens.

Timeouts
--------
If speedrun.com takes longer than 2.5s to respond then we will defer and respond at a later point. This unfortunately breaks discord mentions, but it's an acceptable trade off to the alternative of not responding at all.